### PR TITLE
Enable bootarg in order to force use of RGB colorspace

### DIFF
--- a/projects/Odroid_C2/bootloader/boot.ini
+++ b/projects/Odroid_C2/bootloader/boot.ini
@@ -119,6 +119,11 @@ setenv libreelec "quiet ssh"
 setenv hdmi_cec  "1"                  # Enabled
 
 
+# Force HDMI to use RGB colorspace regardless of TV request
+setenv hdmi_forcergb "0"              # Disabled
+# setenv hdmi_forcergb "1"             # Enabled
+
+
 # Odroid C2 specific
 setenv odroidp1  "no_console_suspend hdmimode=${m} m_bpp=${m_bpp} vout=${vout} disablehpd=${hpd}"
 setenv odroidp2  "${disableuhs} consoleblank=0"
@@ -137,12 +142,13 @@ setenv bootrootfs "boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2"
 
 
 # Prepare to boot
-if test "${hdmi_cec}" = "1"; then setenv cec "hdmitx=cecf"; fi
+if test "${hdmi_cec}" = "1"; then setenv hdmitx "hdmitx=cecf"; fi
+if test "${hdmi_forcergb}" = "1"; then if test "${hdmitx}" = ""; then setenv hdmitx "hdmitx=forcergb"; else setenv hdmitx "${hdmitx},forcergb"; fi; fi
 if test "${nographics}" = "0"; then fdt rm /mesonfb; fdt rm /aocec; fi
 
 
 # Populate the final boot variables
-setenv bootargs "${condev} ${bootrootfs} ${odroid} ${cec} ${libreelec}"
+setenv bootargs "${condev} ${bootrootfs} ${odroid} ${hdmitx} ${libreelec}"
 
 
 # Boot the C2 board

--- a/projects/Odroid_C2/patches/linux/li29-HDMI.Force.RGB.colorspace.patch
+++ b/projects/Odroid_C2/patches/linux/li29-HDMI.Force.RGB.colorspace.patch
@@ -1,0 +1,42 @@
+From c8e1baf6a5b962ffa6696112cbd07b3fe6f876b5 Mon Sep 17 00:00:00 2001
+From: Pablo <pablo@localhost.localdomain>
+Date: Wed, 15 Jun 2016 12:05:53 +0200
+Subject: [PATCH] Enable hdmitx=forcergb on kernel boot in attempt to fix buggy
+ TV firmwares
+
+---
+ drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c      | 3 +++
+ drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c b/drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c
+index 685a1e4..a02ec07 100644
+--- a/drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c
++++ b/drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c
+@@ -2135,6 +2135,9 @@ static  int __init hdmitx_boot_para_setup(char *s)
+ 			hdmitx_device.cec_func_config = list;
+ 		hdmi_print(INF, CEC "HDMI hdmi_cec_func_config:0x%x\n",
+ 			hdmitx_device.cec_func_config);
++		} else if (strcmp(token, "forcergb") == 0) {
++			hdmitx_output_rgb();
++			hdmi_print(IMP, "Forced RGB colorspace output\n");
+ 		}
+ 	}
+ 		offset = token_offset;
+diff --git a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+index 74d4502..1ac1f2a 100644
+--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
++++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+@@ -2470,6 +2470,9 @@ static  int __init hdmitx_boot_para_setup(char *s)
+ 				hdmitx_device.cec_func_config = list;
+ 			hdmi_print(INF, CEC "HDMI hdmi_cec_func_config:0x%x\n",
+ 				   hdmitx_device.cec_func_config);
++		} else if (strcmp(token, "forcergb") == 0) {
++			hdmitx_output_rgb();
++			hdmi_print(IMP, "Forced RGB colorspace output\n");
+ 		}
+ 	}
+ 		offset = token_offset;
+-- 
+2.8.3
+


### PR DESCRIPTION
Some old TVs (tested with Philips) report incorrectly HDMI requests to change colorspace.
The result is an image flooded with green/magenta colors.

This workaround enables a bootarg hdmitx=forcergb in order to ignore the HDMI request
from the TV and use always RGB colorspace. I've only created the bootarg because
the source code to force the colorspace was already there but surprisingly was not being used.

I've also created a pull request over HardKernel/linux so the patch file will be needed until the merge is made, if it does.
